### PR TITLE
BUG修复和优化

### DIFF
--- a/preseed.sh
+++ b/preseed.sh
@@ -104,6 +104,9 @@ fi
 
 preseed="""
 # 预配置文件
+# 低内存模式
+di lowmem/low boolean true 
+di lowmem/insufficient boolean true
 # 语言和地区
 d-i debian-installer/locale string en_US.UTF-8
 d-i keyboard-configuration/xkb-keymap select us


### PR DESCRIPTION
1. 更改为默认使用低内存模式，防止内存小的机器弹出提示而中断自动化安装过程